### PR TITLE
feat: allow use of directories in upload destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ On success, the resulting data structure looks like:
 ## TODO
 
 - GS_USER_KEY expects PEM, not JSON key
-- mkdirp the folder locally before updating
-- use the full path in google/s3 storage
 - 
 
 [travis-url]: https://travis-ci.org/npm-wharf/k8s-tickbot

--- a/spec/backup.spec.js
+++ b/spec/backup.spec.js
@@ -221,14 +221,14 @@ describe('Backup', function () {
             `${LOCAL_PATH}/spec/tmp/two.txt`,
             `${LOCAL_PATH}/spec/tmp/info.json`
           ], `tar-${now.toFormat(DATE_TIME)}.tgz`)
-          .resolves(`./spec/tar-${now.toFormat(DATE_TIME)}.tgz`)
+          .resolves({ escaped: `./spec/tar-${now.toFormat(DATE_TIME)}.tgz`, destination: `tar-${now.toFormat(DATE_TIME)}.tgz` })
 
         bucketMock.expects('enforceLifecycle')
           .once()
           .resolves()
 
         bucketMock.expects('uploadFile')
-          .withArgs(`./spec/tar-${now.toFormat(DATE_TIME)}.tgz`)
+          .withArgs({ escaped: `./spec/tar-${now.toFormat(DATE_TIME)}.tgz`, destination: `tar-${now.toFormat(DATE_TIME)}.tgz` })
           .resolves({
             dir: `${LOCAL_PATH}/spec/`,
             files: [
@@ -249,7 +249,7 @@ describe('Backup', function () {
       it('should return tarball metadata', function () {
         return backup.backupFrom()
           .should.eventually.eql({
-            tar: `./spec/tar-${now.toFormat(DATE_TIME)}.tgz`,
+            tar: { escaped: `./spec/tar-${now.toFormat(DATE_TIME)}.tgz`, destination: `tar-${now.toFormat(DATE_TIME)}.tgz` },
             files: [
               `${LOCAL_PATH}/spec/tmp/one.txt`,
               `${LOCAL_PATH}/spec/tmp/two.txt`

--- a/spec/bucket.spec.js
+++ b/spec/bucket.spec.js
@@ -73,7 +73,6 @@ describe('Bucket', function () {
         })
 
         it('should be rejected with error', function () {
-          console.log(result.stack)
           expect(result.message).to.equal(
             `Could not download tarball 'metrics.tgz':\n\tohno`
           )
@@ -149,7 +148,7 @@ describe('Bucket', function () {
             })
             .returns(uploads)
 
-          bucket.uploadFile(fullPath)
+          bucket.uploadFile({ escaped: fullPath, destination: 'metrics.tgz' })
             .then(
               null,
               err => { result = err }
@@ -189,7 +188,7 @@ describe('Bucket', function () {
             })
             .returns(uploads)
 
-          bucket.uploadFile(fullPath)
+          bucket.uploadFile({ escaped: fullPath, destination: 'metrics.tgz' })
             .then(
               x => { result = x }
             )
@@ -201,7 +200,10 @@ describe('Bucket', function () {
         it('should resolve with metadata', function () {
           expect(result).to.eql({
             dir: path.dirname(fullPath),
-            file: fullPath
+            file: {
+              escaped: fullPath,
+              destination: 'metrics.tgz'
+            }
           })
           s3Mock.verify()
         })
@@ -774,10 +776,10 @@ describe('Bucket', function () {
             .returns(gsBucket)
           bucketMock
             .expects('upload')
-            .withArgs(fullPath)
+            .withArgs(fullPath, { destination: 'metrics.tgz' })
             .rejects(new Error('ohno'))
 
-          return bucket.uploadFile(fullPath)
+          return bucket.uploadFile({ escaped: fullPath, destination: 'metrics.tgz' })
             .then(
               null,
               err => { result = err }
@@ -810,10 +812,10 @@ describe('Bucket', function () {
             .returns(gsBucket)
           bucketMock
             .expects('upload')
-            .withArgs(fullPath)
+            .withArgs(fullPath, { destination: 'metrics.tgz' })
             .resolves({})
 
-          return bucket.uploadFile(fullPath)
+          return bucket.uploadFile({ escaped: fullPath, destination: 'metrics.tgz' })
           .then(
             x => { result = x }
           )
@@ -822,7 +824,10 @@ describe('Bucket', function () {
         it('should return undefined', function () {
           result.should.eql({
             dir: path.dirname(fullPath),
-            file: fullPath
+            file: {
+              escaped: fullPath,
+              destination: 'metrics.tgz'
+            }
           })
           gsMock.verify()
           bucketMock.verify()

--- a/src/backup.js
+++ b/src/backup.js
@@ -122,8 +122,8 @@ function uploadTarball (config, bucket, tgz) {
     .then(
       () => {
         log.info(`Backup completed successfully.`)
-        if (fs.existsSync(tgz)) {
-          fs.unlinkSync(tgz)
+        if (fs.existsSync(tgz.escaped)) {
+          fs.unlinkSync(tgz.escaped)
         }
         return {}
       },
@@ -131,8 +131,8 @@ function uploadTarball (config, bucket, tgz) {
         const msg = `Failed to upload tarball to configured object store. Backup has failed. ${e.stack}`
         const err = new Error(msg)
         log.error(msg)
-        if (fs.existsSync(tgz)) {
-          fs.unlinkSync(tgz)
+        if (fs.existsSync(tgz.escaped)) {
+          fs.unlinkSync(tgz.escaped)
         }
         throw err
       }

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -285,37 +285,36 @@ function sortByDate (a, b) {
 }
 
 function uploadFile (api, config, file) {
-  const dir = path.dirname(file)
+  const dir = path.dirname(file.escaped)
   if (api.gs) {
     return api.gs
       .bucket(config.storage.bucket)
-      .upload(file)
+      .upload(file.escaped, { destination: file.destination })
       .then(
         () => {
-          log.info(`Uploaded tarball '${file}' to bucket '${config.storage.bucket}' successfully`)
+          log.info(`Uploaded tarball '${file.destination}' to bucket '${config.storage.bucket}' successfully`)
           return { file, dir }
         },
         err => {
-          log.info(`Could not upload tarball '${file}' to bucket '${config.storage.bucket}':\n\t${err.message}`)
+          log.info(`Could not upload tarball '${file.destination}' to bucket '${config.storage.bucket}':\n\t${err.message}`)
           throw err
         }
       )
   } else {
     return new Promise((resolve, reject) => {
-      const fileName = path.basename(file)
       const upload = api.s3.uploadFile({
-        localFile: file,
+        localFile: file.escaped,
         s3Params: {
           Bucket: config.storage.bucket,
-          Key: fileName
+          Key: file.destination
         }
       })
       upload.on('error', err => {
-        log.info(`Could not upload tarball '${file}' to bucket '${config.storage.bucket}':\n\t${err.message}`)
+        log.info(`Could not upload tarball '${file.destination}' to bucket '${config.storage.bucket}':\n\t${err.message}`)
         reject(err)
       })
       upload.on('end', () => {
-        log.info(`Uploaded tarball '${file}' to bucket '${config.storage.bucket}' successfully`)
+        log.info(`Uploaded tarball '${file.destination}' to bucket '${config.storage.bucket}' successfully`)
         resolve({ file, dir })
       })
     })

--- a/src/tar.js
+++ b/src/tar.js
@@ -34,7 +34,7 @@ function unzipFiles (dataPath, tarball) {
 }
 
 function zipFiles (relativePath, files, archive) {
-  const tgzFile = path.join(process.cwd(), archive)
+  const tgzFile = path.join(process.cwd(), archive.replace(new RegExp(path.sep, 'g'), '_'))
   return tar.c(
     {
       gzip: true,
@@ -46,7 +46,7 @@ function zipFiles (relativePath, files, archive) {
   ).then(
     () => {
       log.info(`Created tarball with files '${files.join(', ')}'`)
-      return tgzFile
+      return { escaped: tgzFile, destination: archive }
     },
     err => {
       log.error(`Failed to create tarball for files - '${files.join(', ')}' with error:\n\t${err.message}`)


### PR DESCRIPTION
this lets us namespace archives by directory, rather than just by filename.
it also eliminates the issue with needing to create the local directory before the tarball by escaping `path.sep` to an underscore.