### PR TITLE
BREAKING CHANGE: change from lodash default delimiters to handlebar delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A module to help with the task of archiving data tarballed, gzipped data to an o
 Endpoints and connection configuration are set via environment variables:
 
  * `OBJECT_STORE` - the object store where tasks and grafs are stored and retrieved from
- * `FILE_NAME_FORMAT` - uses templating to specify a pattern for creating tarball names. Tokens are escaped with `<%=` `%>`.
+ * `FILE_NAME_FORMAT` - uses templating to specify a pattern for creating tarball names. Tokens are escaped with `{{` `}}`.
     * All dates and times for tokens are UTC
       * `dateTime` - provides date and time: `mm_dd_yy_HH_MM_SS`
       * `date` - provides date: `mm_dd_yy`

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bole": "^3.0.2",
     "globulesce": "^1.0.0",
     "lodash.template": "^4.4.0",
+    "lodash.templatesettings": "^4.1.0",
     "luxon": "^1.2.1",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.2",

--- a/spec/backup.spec.js
+++ b/spec/backup.spec.js
@@ -34,7 +34,7 @@ describe('Backup', function () {
   describe('when getting file name', function () {
     it('should get default', function () {
       let backup = Backup({
-        fileName: 'archive_<%=date%>'
+        fileName: 'archive_{{date}}'
       })
       let date = now.toFormat(DATE)
       backup.getFileName().should.eql(`archive_${date}`)
@@ -42,7 +42,7 @@ describe('Backup', function () {
 
     it('should get date based template', function () {
       let backup = Backup({
-        fileName: 'my-file-name-<%=date%>.tgz'
+        fileName: 'my-file-name-{{date}}.tgz'
       })
       let date = now.toFormat(DATE)
       backup.getFileName().should.eql(`my-file-name-${date}.tgz`)
@@ -50,7 +50,7 @@ describe('Backup', function () {
 
     it('should get time based template', function () {
       let backup = Backup({
-        fileName: 'my-file-name-<%=time%>.tgz'
+        fileName: 'my-file-name-{{time}}.tgz'
       })
       let time = now.toFormat(TIME)
       backup.getFileName().should.eql(`my-file-name-${time}.tgz`)
@@ -58,7 +58,7 @@ describe('Backup', function () {
 
     it('should get datetime based template', function () {
       let backup = Backup({
-        fileName: 'my-file-name-<%=dateTime%>.tgz'
+        fileName: 'my-file-name-{{dateTime}}.tgz'
       })
       let dateTime = now.toFormat(DATE_TIME)
       backup.getFileName().should.eql(`my-file-name-${dateTime}.tgz`)
@@ -241,7 +241,7 @@ describe('Backup', function () {
         backup = Backup({
           basePath: './spec',
           dataPath: 'tmp',
-          fileName: 'tar-<%=dateTime%>.tgz',
+          fileName: 'tar-{{dateTime}}.tgz',
           patterns: ['**/*']
         }, globulesce.glob, tar, bucket)
       })

--- a/spec/bucket.spec.js
+++ b/spec/bucket.spec.js
@@ -640,7 +640,7 @@ describe('Bucket', function () {
             ]})
 
           bucket = Bucket(s3API, {
-            fileName: 'archive-<%=date%>.tgz',
+            fileName: 'archive-{{date}}.tgz',
             storage: {
               bucket: 'test-bucket'
             }
@@ -1265,7 +1265,7 @@ describe('Bucket', function () {
             .rejects(new Error('nope'))
 
           bucket = Bucket(gsAPI, {
-            fileName: 'archive-<%=date%>.tgz',
+            fileName: 'archive-{{date}}.tgz',
             storage: {
               bucket: 'test-bucket'
             }
@@ -1304,7 +1304,7 @@ describe('Bucket', function () {
             .resolves([])
 
           bucket = Bucket(gsAPI, {
-            fileName: 'archive-<%=date%>.tgz',
+            fileName: 'archive-{{date}}.tgz',
             storage: {
               bucket: 'test-bucket'
             }
@@ -1367,7 +1367,7 @@ describe('Bucket', function () {
             ])
 
           bucket = Bucket(gsAPI, {
-            fileName: 'archive-<%=date%>.tgz',
+            fileName: 'archive-{{date}}.tgz',
             storage: {
               bucket: 'test-bucket'
             }

--- a/src/backup.js
+++ b/src/backup.js
@@ -4,6 +4,8 @@ const mkdirp = require('mkdirp')
 const log = require('bole')('backup')
 const { DateTime } = require('luxon')
 const template = require('lodash.template')
+const templateSettings = require('lodash.templatesettings')
+templateSettings.interpolate = /{{([\s\S]+?)}}/g
 
 const DATE_TIME = `yyyy-MM-dd_HH:mm:ss`
 const DATE = `yyyy-MM-dd`

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -79,7 +79,7 @@ function enforceLifecycle (api, config) {
 
 function getFilePrefix (fileName) {
   if (fileName) {
-    let [prefix] = fileName.split('<%')
+    let [prefix] = fileName.split('{{')
     return prefix
   } else {
     return ''

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 module.exports = {
   basePath: process.env.BASE_PATH || process.cwd(),
   dataPath: process.env.DATA_PATH || 'archive',
-  fileName: process.env.FILE_NAME_FORMAT || 'archive_{{date}}',
+  fileName: process.env.FILE_NAME_FORMAT || 'archive_{{date}}.tgz',
   patterns: (process.env.FILE_PATTERNS || '**/*').split(','),
   storage: {
     bucket: process.env.OBJECT_STORE,

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 module.exports = {
   basePath: process.env.BASE_PATH || process.cwd(),
   dataPath: process.env.DATA_PATH || 'archive',
-  fileName: process.env.FILE_NAME_FORMAT || 'archive_<%=date%>',
+  fileName: process.env.FILE_NAME_FORMAT || 'archive_{{date}}',
   patterns: (process.env.FILE_PATTERNS || '**/*').split(','),
   storage: {
     bucket: process.env.OBJECT_STORE,


### PR DESCRIPTION
We can't pass a templated filename as an env var in a mcgonagall spec because McG always expands them.  If we escape the template delimiter, then cloud-archive doesn't evaluate it, leading to backups named `archive-\<%=dateTime%\>.tgz`.  This PR changes delimeters to `{{` and `}}` as a workaround.