### PR TITLE
fix: download files correctly

### DIFF
--- a/spec/bucket.spec.js
+++ b/spec/bucket.spec.js
@@ -1306,7 +1306,7 @@ describe('Bucket', function () {
               autoPaginate: false,
               prefix: 'archive-'
             })
-            .resolves([])
+            .resolves([[]])
 
           bucket = Bucket(gsAPI, {
             fileName: 'archive-{{date}}.tgz',
@@ -1343,7 +1343,7 @@ describe('Bucket', function () {
               autoPaginate: false,
               prefix: 'archive-'
             })
-            .resolves([
+            .resolves([[
               {
                 name: 'archive-2018-05-29_03:00:00.tgz',
                 timeCreated: '2018-05-29T03:00:00Z',
@@ -1369,7 +1369,7 @@ describe('Bucket', function () {
                 timeCreated: '2018-05-25T03:00:00Z',
                 updated: '2018-05-31T03:00:00Z'
               }
-            ])
+            ]])
 
           bucket = Bucket(gsAPI, {
             fileName: 'archive-{{date}}.tgz',

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -9,7 +9,7 @@ function downloadFile (api, config, fileName) {
   if (!fs.existsSync(dir)) {
     mkdirp.sync(dir)
   }
-  const file = path.join(dir, fileName)
+  const file = path.join(dir, fileName.replace(new RegExp(path.sep, 'g'), '_'))
   if (api.gs) {
     log.info(`Attempting to download '${fileName}' from '${config.storage.bucket}'`)
     return api.gs
@@ -100,7 +100,7 @@ function getLatestFile (api, config) {
       .bucket(config.storage.bucket)
       .getFiles(options)
       .then(
-        files => {
+        ([files]) => {
           files.sort(sortByDate)
           return files.length ? files[0].name : undefined
         },


### PR DESCRIPTION
the `getFiles` method returns an array where the first member is an array of files per https://cloud.google.com/nodejs/docs/reference/storage/2.3.x/Bucket#getFiles (see the bottom of the example code)